### PR TITLE
Fix Windows.

### DIFF
--- a/src/bin/cataloger.rs
+++ b/src/bin/cataloger.rs
@@ -10,6 +10,8 @@ use clientele::{
 use miette::{Result, miette};
 // use oxrdf::{Literal, NamedNode, Triple};
 
+use asimov_telegram_module::shared;
+
 /// ASIMOV Telegram Cataloger
 #[derive(Debug, Parser)]
 #[command(name = "asimov-telegram-cataloger", long_about)]
@@ -47,14 +49,7 @@ async fn main() -> Result<SysexitsError> {
         return Ok(EX_OK);
     }
 
-    let Some(data_dir) =
-        clientele::paths::xdg_data_home().map(|p| p.join("asimov-telegram-module"))
-    else {
-        return Err(miette!(
-            "Unable to determine a directory for data. Neither $XDG_DATA_HOME nor $HOME available."
-        ));
-    };
-
+    let data_dir = shared::get_data_dir()?;
     let manifest = ModuleManifest::read_manifest("telegram").unwrap();
 
     let api_id = manifest

--- a/src/bin/configurator.rs
+++ b/src/bin/configurator.rs
@@ -10,6 +10,8 @@ use clientele::{
 use miette::{Result, miette};
 use std::io::{BufRead, Write};
 
+use asimov_telegram_module::shared;
+
 /// ASIMOV Telegram Configurator
 #[derive(Debug, Parser)]
 #[command(name = "asimov-telegram-configurator", long_about)]
@@ -54,14 +56,7 @@ async fn main() -> Result<SysexitsError> {
         return Ok(EX_OK);
     }
 
-    let Some(data_dir) =
-        clientele::paths::xdg_data_home().map(|p| p.join("asimov-telegram-module"))
-    else {
-        return Err(miette!(
-            "Unable to determine a directory for data. Neither $XDG_DATA_HOME nor $HOME available."
-        ));
-    };
-
+    let data_dir = shared::get_data_dir()?;
     let manifest = ModuleManifest::read_manifest("telegram").unwrap();
 
     let api_id = manifest

--- a/src/bin/fetcher.rs
+++ b/src/bin/fetcher.rs
@@ -11,6 +11,8 @@ use futures::StreamExt;
 use miette::{IntoDiagnostic, Result, miette};
 use std::sync::Arc;
 
+use asimov_telegram_module::shared;
+
 #[derive(Debug, Parser)]
 #[command(
     name = "asimov-telegram-fetcher",
@@ -56,14 +58,7 @@ async fn main() -> Result<SysexitsError> {
         return Ok(EX_OK);
     }
 
-    let Some(data_dir) =
-        clientele::paths::xdg_data_home().map(|p| p.join("asimov-telegram-module"))
-    else {
-        return Err(miette!(
-            "Unable to determine a directory for data. Neither $XDG_DATA_HOME nor $HOME available."
-        ));
-    };
-
+    let data_dir = shared::get_data_dir()?;
     let manifest = ModuleManifest::read_manifest("telegram").unwrap();
 
     let api_id = manifest

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,4 +6,5 @@
 extern crate std;
 
 pub mod jq;
+pub mod shared;
 pub mod telegram;

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -1,0 +1,19 @@
+use clientele::Utf8PathBuf;
+use miette::{Result, miette};
+use std::format;
+
+pub fn get_data_dir() -> Result<clientele::Utf8PathBuf> {
+    const MODULE_NAME: &str = "asimov-telegram-module";
+
+    #[cfg(unix)]
+    return clientele::paths::xdg_data_home().map(|p| p.join(MODULE_NAME)).ok_or_else(|| miette!(
+            "Unable to determine a directory for data. Neither $XDG_DATA_HOME nor $HOME available."
+        ));
+
+    #[cfg(windows)]
+    return clientele::envs::windows::appdata()
+        .map(|p| Utf8PathBuf::from(p).join(MODULE_NAME))
+        .ok_or_else(|| {
+            miette!("Unable to determine a directory for data. %APPDATA% is not available.")
+        });
+}


### PR DESCRIPTION
There are no `XDG_DATA_HOME` or `HOME` environment variables on Windows, making this module fail on startup. This PR fixes it by using `APPDATA` environment variable on Windows instead.